### PR TITLE
Use the Java compiler version 1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,8 @@
   </distributionManagement>
 
   <properties>
+    <maven.compiler.source>1.6</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding> 
   </properties>


### PR DESCRIPTION
Compiling the project with maven gives an error. The default compiler for maven is still Java 1.5 which is no longer supported.

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project crc: Compilation failure: Compilation failure: 
[ERROR] Source option 5 is no longer supported. Use 6 or later.
[ERROR] Target option 1.5 is no longer supported. Use 1.6 or later.
